### PR TITLE
Search by email prefix feature

### DIFF
--- a/src/components/admin/Dialogs/SearchDialog.js
+++ b/src/components/admin/Dialogs/SearchDialog.js
@@ -1,0 +1,119 @@
+// @flow
+import * as React from 'react';
+import {UserRow} from '../UserRow';
+import {deleteUser, updateAdminNote} from '../../database/Queries';
+import type {UserType} from '../../types/FlowTypes.js';
+import {
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+} from '@material-ui/core';
+
+import {
+  TableContainer,
+  Table,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from '@material-ui/core';
+
+type PropType = {
+  open: boolean,
+  onClose: () => void,
+  rows: Array<UserType>
+};
+
+export const SearchDialog = (props: PropType): React.Node => {
+  const {open, onClose, rows} = props;
+  const [selectedRow, setSelectedRow] = React.useState(-1);
+  const [selectedDelete, setSelectedDelete] = React.useState(-1);
+
+  const handleSelectedRow = (rowId: number) => {
+    setSelectedRow(rowId);
+  };
+
+  const handleCloseModal = () => {
+    setSelectedRow(-1);
+  };
+
+  const handleOpenDialog = (rowId: number) => {
+    setSelectedDelete(rowId);
+  };
+
+  const handleCloseDialog = () => {
+    setSelectedDelete(-1);
+  };
+
+  const handleConfirmDelete = async () => {
+    try {
+      await deleteUser('count', selectedDelete);
+      setSelectedDelete(-1);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  const saveNote = async (user: UserType, note: string) => {
+    try {
+      await updateAdminNote('email', user.email, note);
+    } catch (error) {
+      console.log(error);
+    } finally {
+      window.location.reload();
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      scroll={'paper'}>
+      <DialogTitle>
+        Search Results
+      </DialogTitle>
+      <DialogContent>
+        {rows.length > 0 ?
+        (<TableContainer>
+          <Table size='small'>
+            <TableHead>
+              <TableRow>
+                <TableCell>Name</TableCell>
+                <TableCell>Email</TableCell>
+                <TableCell></TableCell>
+                <TableCell></TableCell>
+              </TableRow>
+            </TableHead>
+
+            <TableBody>
+              {rows.map((row: UserType): React.Node => (
+                <UserRow
+                  key={row.count}
+                  open={row.count === selectedRow}
+                  row={row}
+                  openDelete={selectedDelete === row.count}
+                  handleRow={handleSelectedRow}
+                  handleOpenDialog={handleOpenDialog}
+                  handleCloseDialog={handleCloseDialog}
+                  handleConfirmDelete={handleConfirmDelete}
+                  saveNote={saveNote}
+                  handleCloseModal={handleCloseModal}/>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>) :
+        (<DialogContentText>
+          No search results could be found.
+        </DialogContentText>)}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>
+          Back
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/src/components/admin/SearchToolbar.js
+++ b/src/components/admin/SearchToolbar.js
@@ -39,7 +39,7 @@ export default function SearchToolbar(): React.Node {
   const handleOnSubmit = (event: SyntheticEvent<>) => {
     event.preventDefault();
     const searchText = text.split(/\s+/).join(' ');
-    if (searchText === '' || searchText === null) {
+    if (searchText === null || searchText === '') {
       return;
     }
     setFinal(searchText);

--- a/src/components/admin/SearchToolbar.js
+++ b/src/components/admin/SearchToolbar.js
@@ -17,7 +17,7 @@ export default function SearchToolbar(): React.Node {
 
   React.useEffect(() => {
     (async () => {
-      if (final !== '' && final !== null) {
+      if (final !== null && final !== '') {
         const newRows = await searchByEmail(final);
         setRows(newRows);
       }

--- a/src/components/admin/SearchToolbar.js
+++ b/src/components/admin/SearchToolbar.js
@@ -1,0 +1,77 @@
+// @flow
+import * as React from 'react';
+import TextField from '@material-ui/core/TextField';
+import {searchByEmail} from '../database/Queries';
+import Toolbar from '@material-ui/core/Toolbar';
+import Typography from '@material-ui/core/Typography';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import SearchIcon from '@material-ui/icons/Search';
+import {SearchDialog} from './Dialogs/SearchDialog';
+import styles from './admin.module.css';
+
+export default function SearchToolbar(): React.Node {
+  const [search, setSearch] = React.useState(false);
+  const [rows, setRows] = React.useState([]);
+  const [text, setText] = React.useState('');
+  const [final, setFinal] = React.useState('');
+
+  React.useEffect(() => {
+    (async () => {
+      if (final !== '' && final !== null) {
+        const newRows = await searchByEmail(final);
+        setRows(newRows);
+      }
+    })();
+  }, [final]);
+
+  const handleOnSearchClose = () => {
+    setSearch(false);
+  };
+
+  const handleOnSearchOpen = () => {
+    setSearch(true);
+  };
+
+  const handleChange = (event: SyntheticEvent<>) => {
+    setText(event.target.value);
+  };
+
+  const handleOnSubmit = (event: SyntheticEvent<>) => {
+    event.preventDefault();
+    const searchText = text.split(/\s+/).join(' ');
+    if (searchText === '' || searchText === null) {
+      return;
+    }
+    setFinal(searchText);
+    handleOnSearchOpen();
+  };
+
+  return (
+    <Toolbar variant='dense' className={styles.titleUsersBar}>
+      <Typography variant='h6' className={styles.titleUsersText}>
+        Active members
+      </Typography>
+      <form onSubmit={handleOnSubmit}>
+        <TextField
+          id='outlined-margin-dense'
+          placeholder='Search users by email...'
+          margin='dense'
+          variant='outlined'
+          value={text}
+          onChange={handleChange}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position='start'>
+                <SearchIcon />
+              </InputAdornment>
+            ),
+          }}
+        />
+      </form>
+      <SearchDialog
+        open={search}
+        onClose={(): void => handleOnSearchClose()}
+        rows={rows} />
+    </Toolbar>
+  );
+}

--- a/src/components/admin/Tables/UsersTable.js
+++ b/src/components/admin/Tables/UsersTable.js
@@ -14,17 +14,14 @@ import TableFooter from '@material-ui/core/TableFooter';
 import TablePagination from '@material-ui/core/TablePagination';
 import styles from '../admin.module.css';
 import {Typography} from '@material-ui/core';
-import DeleteIcon from '@material-ui/icons/Delete';
 import SearchIcon from '@material-ui/icons/Search';
-import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
-import IconButton from '@material-ui/core/IconButton';
-import DeleteDialog from '../Dialogs/DeleteDialog';
+//import {SearchDialog} from '../Dialogs/SearchDialog';
+import {UserRow} from '../UserRow';
 
 import {
   TablePaginationActions,
   computeEmptyRows,
 } from '../TablePaginationActions';
-import UserInfo from '../Dialogs/UserInfo';
 import type {UserType} from '../../types/FlowTypes.js';
 import {
   getActiveMembers,
@@ -44,7 +41,7 @@ function EnhancedToolbar(): React.Node {
       <form onSubmit={handleOnSubmit}>
         <TextField
           id='outlined-margin-dense'
-          placeholder='Search users...'
+          placeholder='Search users by email...'
           margin='dense'
           variant='outlined'
           InputProps={{
@@ -67,6 +64,7 @@ export default function UsersTable(): React.Node {
   const [selectedDelete, setSelectedDelete] = React.useState(-1);
   const [rows, setRows] = React.useState([]);
   const [counter, setCounter] = React.useState(0);
+  //const [search, setSearch] = React.useState(false);
 
   React.useEffect(() => {
     (async () => {
@@ -137,39 +135,18 @@ export default function UsersTable(): React.Node {
           </TableHead>
 
           <TableBody>
-            {rows
-                .map((row: UserType): React.Node => (
-                  <TableRow
-                    key={row.count} >
-                    <TableCell>{row.name}</TableCell>
-                    <TableCell>{row.email}</TableCell>
-                    <TableCell>
-                      <IconButton
-                        onClick={(): void =>
-                          handleSelectedRow(row.count)}>
-                        <InfoOutlinedIcon/>
-                      </IconButton>
-                    </TableCell>
-                    <TableCell>
-                      <IconButton
-                        onClick={(event: any): void =>
-                          handleOpenDialog(row.count)}>
-                        <DeleteIcon/>
-                      </IconButton>
-                    </TableCell>
-                    <DeleteDialog
-                      user={row}
-                      open={selectedDelete === row.count}
-                      onClose={handleCloseDialog}
-                      onConfirm={handleConfirmDelete} />
-                    <UserInfo
-                      user={row}
-                      open={selectedRow === row.count}
-                      onClose={handleCloseModal}
-                      saveNote={saveNote}>
-                    </UserInfo>
-                  </TableRow>
-                ))}
+            {rows.map((row: UserType): React.Node => (
+              <UserRow
+                key={row.count}
+                row={row}
+                open={selectedRow === row.count}
+                openDelete={selectedDelete === row.count}
+                handleRow={handleSelectedRow}
+                handleOpenDialog={handleOpenDialog}
+                handleConfirmDelete={handleConfirmDelete}
+                handleCloseDialog={handleCloseDialog}
+                saveNote={saveNote}
+                handleCloseModal={handleCloseModal} />))}
             {computeEmptyRows(rowsPerPage, page, rows) > 0 && (
               <TableRow style={{height: 42.4 *
                     computeEmptyRows(rowsPerPage, page, rows)}}>

--- a/src/components/admin/Tables/UsersTable.js
+++ b/src/components/admin/Tables/UsersTable.js
@@ -4,20 +4,14 @@ import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableContainer from '@material-ui/core/TableContainer';
-import TextField from '@material-ui/core/TextField';
-import Toolbar from '@material-ui/core/Toolbar';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
-import InputAdornment from '@material-ui/core/InputAdornment';
 import Paper from '@material-ui/core/Paper';
 import TableFooter from '@material-ui/core/TableFooter';
 import TablePagination from '@material-ui/core/TablePagination';
 import styles from '../admin.module.css';
-import {Typography} from '@material-ui/core';
-import SearchIcon from '@material-ui/icons/Search';
-import {SearchDialog} from '../Dialogs/SearchDialog';
 import {UserRow} from '../UserRow';
-
+import SearchToolbar from '../SearchToolbar';
 import {
   TablePaginationActions,
   computeEmptyRows,
@@ -28,76 +22,7 @@ import {
   getCounter,
   deleteUser,
   updateAdminNote,
-  searchByEmail,
 } from '../../database/Queries.js';
-
-function EnhancedToolbar(): React.Node {
-  const [search, setSearch] = React.useState(false);
-  const [rows, setRows] = React.useState([]);
-  const [text, setText] = React.useState('');
-  const [final, setFinal] = React.useState('');
-
-  React.useEffect(() => {
-    (async () => {
-      if (final !== '' && final !== null) {
-        const newRows = await searchByEmail(final);
-        setRows(newRows);
-      }
-    })();
-  }, [final]);
-
-  const handleOnSearchClose = () => {
-    setSearch(false);
-  };
-
-  const handleOnSearchOpen = () => {
-    setSearch(true);
-  };
-
-  const handleChange = (event: SyntheticEvent<>) => {
-    setText(event.target.value);
-  };
-
-  const handleOnSubmit = (event: SyntheticEvent<>) => {
-    event.preventDefault();
-    console.log('User has pressed search.');
-    const searchText = text.split(/\s+/).join(' ');
-    if (searchText === '' || searchText === null) {
-      return;
-    }
-    setFinal(searchText);
-    handleOnSearchOpen();
-  };
-
-  return (
-    <Toolbar variant='dense' className={styles.titleUsersBar}>
-      <Typography variant='h6' className={styles.titleUsersText}>
-        Active members
-      </Typography>
-      <form onSubmit={handleOnSubmit}>
-        <TextField
-          id='outlined-margin-dense'
-          placeholder='Search users by email...'
-          margin='dense'
-          variant='outlined'
-          value={text}
-          onChange={handleChange}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position='start'>
-                <SearchIcon />
-              </InputAdornment>
-            ),
-          }}
-        />
-      </form>
-      <SearchDialog
-        open={search}
-        onClose={(): void => handleOnSearchClose()}
-        rows={rows} />
-    </Toolbar>
-  );
-}
 
 export default function UsersTable(): React.Node {
   const [page, setPage] = React.useState(0);
@@ -163,7 +88,7 @@ export default function UsersTable(): React.Node {
 
   return (
     <Paper>
-      <EnhancedToolbar/>
+      <SearchToolbar />
       <TableContainer>
         <Table aria-label='Active members' size='small'>
           <TableHead>

--- a/src/components/admin/Tables/UsersTable.js
+++ b/src/components/admin/Tables/UsersTable.js
@@ -15,7 +15,7 @@ import TablePagination from '@material-ui/core/TablePagination';
 import styles from '../admin.module.css';
 import {Typography} from '@material-ui/core';
 import SearchIcon from '@material-ui/icons/Search';
-//import {SearchDialog} from '../Dialogs/SearchDialog';
+import {SearchDialog} from '../Dialogs/SearchDialog';
 import {UserRow} from '../UserRow';
 
 import {
@@ -28,10 +28,46 @@ import {
   getCounter,
   deleteUser,
   updateAdminNote,
+  searchByEmail,
 } from '../../database/Queries.js';
 
 function EnhancedToolbar(): React.Node {
-  const handleOnSubmit = (): void => console.log('User has pressed search.');
+  const [search, setSearch] = React.useState(false);
+  const [rows, setRows] = React.useState([]);
+  const [text, setText] = React.useState('');
+  const [final, setFinal] = React.useState('');
+
+  React.useEffect(() => {
+    (async () => {
+      if (final !== '' && final !== null) {
+        const newRows = await searchByEmail(final);
+        setRows(newRows);
+      }
+    })();
+  }, [final]);
+
+  const handleOnSearchClose = () => {
+    setSearch(false);
+  };
+
+  const handleOnSearchOpen = () => {
+    setSearch(true);
+  };
+
+  const handleChange = (event: SyntheticEvent<>) => {
+    setText(event.target.value);
+  };
+
+  const handleOnSubmit = (event: SyntheticEvent<>) => {
+    event.preventDefault();
+    console.log('User has pressed search.');
+    const searchText = text.split(/\s+/).join(' ');
+    if (searchText === '' || searchText === null) {
+      return;
+    }
+    setFinal(searchText);
+    handleOnSearchOpen();
+  };
 
   return (
     <Toolbar variant='dense' className={styles.titleUsersBar}>
@@ -44,6 +80,8 @@ function EnhancedToolbar(): React.Node {
           placeholder='Search users by email...'
           margin='dense'
           variant='outlined'
+          value={text}
+          onChange={handleChange}
           InputProps={{
             startAdornment: (
               <InputAdornment position='start'>
@@ -53,6 +91,10 @@ function EnhancedToolbar(): React.Node {
           }}
         />
       </form>
+      <SearchDialog
+        open={search}
+        onClose={(): void => handleOnSearchClose()}
+        rows={rows} />
     </Toolbar>
   );
 }
@@ -64,7 +106,6 @@ export default function UsersTable(): React.Node {
   const [selectedDelete, setSelectedDelete] = React.useState(-1);
   const [rows, setRows] = React.useState([]);
   const [counter, setCounter] = React.useState(0);
-  //const [search, setSearch] = React.useState(false);
 
   React.useEffect(() => {
     (async () => {
@@ -122,7 +163,7 @@ export default function UsersTable(): React.Node {
 
   return (
     <Paper>
-      <EnhancedToolbar />
+      <EnhancedToolbar/>
       <TableContainer>
         <Table aria-label='Active members' size='small'>
           <TableHead>

--- a/src/components/admin/UserRow.js
+++ b/src/components/admin/UserRow.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import DeleteDialog from './Dialogs/DeleteDialog';
 import DeleteIcon from '@material-ui/icons/Delete';
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
-// @flow
 import UserInfo from './Dialogs/UserInfo';
 import {TableRow, TableCell} from '@material-ui/core';
 import {IconButton} from '@material-ui/core';

--- a/src/components/admin/UserRow.js
+++ b/src/components/admin/UserRow.js
@@ -1,0 +1,68 @@
+// @flow
+import * as React from 'react';
+import DeleteDialog from './Dialogs/DeleteDialog';
+import DeleteIcon from '@material-ui/icons/Delete';
+import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
+// @flow
+import UserInfo from './Dialogs/UserInfo';
+import {TableRow, TableCell} from '@material-ui/core';
+import {IconButton} from '@material-ui/core';
+import type {UserType} from '../types/FlowTypes';
+
+type PropType = {
+  row: UserType,
+  open: boolean,
+  openDelete: boolean,
+  handleRow: (number) => void,
+  handleOpenDialog: (number) => void,
+  handleCloseDialog: () => void,
+  handleConfirmDelete: () => Promise<any>,
+  saveNote: (UserType, string) => Promise<any>,
+  handleCloseModal: () => void
+};
+
+export const UserRow = (props: PropType): React.Node => {
+  const {
+    row,
+    open,
+    openDelete,
+    handleRow,
+    handleOpenDialog,
+    handleCloseDialog,
+    handleConfirmDelete,
+    saveNote,
+    handleCloseModal,
+  } = props;
+
+  return (
+    <TableRow key={row.count} >
+      <TableCell>{row.name}</TableCell>
+      <TableCell>{row.email}</TableCell>
+      <TableCell>
+        <IconButton
+          onClick={(): void =>
+            handleRow(row.count)}>
+          <InfoOutlinedIcon/>
+        </IconButton>
+      </TableCell>
+      <TableCell>
+        <IconButton
+          onClick={(event: any): void =>
+            handleOpenDialog(row.count)}>
+          <DeleteIcon/>
+        </IconButton>
+      </TableCell>
+      <DeleteDialog
+        user={row}
+        open={openDelete}
+        onClose={handleCloseDialog}
+        onConfirm={handleConfirmDelete} />
+      <UserInfo
+        user={row}
+        open={open}
+        onClose={handleCloseModal}
+        saveNote={saveNote}>
+      </UserInfo>
+    </TableRow>
+  );
+};

--- a/src/components/database/Queries.js
+++ b/src/components/database/Queries.js
@@ -294,6 +294,26 @@ async function findUserByEmailQuery(userEmail: string): Promise<any> {
   }
 }
 
+async function searchByEmail(email: string): Promise<any> {
+  try {
+    const usersRef = database.collection('active-members');
+    const snapshot = await usersRef
+        .where('email', '>=', email)
+        .where('email', '<', email + '\uf8ff')
+        .get();
+
+    const results = snapshot.docs
+        .map((doc: any): any => doc.data())
+        .map((doc: any): UserType | PendingType | ActionType =>
+          sanitize('active-members', doc));
+
+    return results;
+  } catch (error) {
+    console.log(error);
+    return [];
+  }
+}
+
 export {
   getActions,
   getActiveMembers,
@@ -306,4 +326,5 @@ export {
   updateAdminNote,
   movePendingUser,
   moveSolvedAction,
+  searchByEmail,
 };


### PR DESCRIPTION
This branch adds a new dialog to the admin side, that returns the results of a search query for the `active-members` table. Firestore only supports search by prefix, so this branch implements a search that returns all users that have an email address with a prefix identical to the submitted one. 